### PR TITLE
Add active class to active navbar page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -69,6 +69,29 @@ module.exports = function (eleventyConfig) {
         }
     );
 
+    eleventyConfig.addLiquidTag('navbarLink', function (liquidEngine) {
+        return {
+            parse: function (tagToken, remainingTokens) {
+                // there's a better way to do this that's not in 11ty yet
+                // https://github.com/11ty/eleventy/issues/2679
+                let args = tagToken.args.split(' ');
+                args = Object.fromEntries(args.map(arg => arg.split('=')));
+                this.hrefLink = args.link;
+                this.navbarLinkName = args.navbarLinkName;
+            },
+            render: async function (scope, hash) {
+                const context = scope.environments;
+                const pageUrl = context.page.url;
+                let href = await liquidEngine.evalValue(this.hrefLink, scope);
+                href += href.endsWith('/') ? '' : '/';
+                const name = await liquidEngine.evalValue(this.navbarLinkName, scope);
+                const activeLinkClass = pageUrl === href ? ' class="active"' : '';
+
+                return `<a ${activeLinkClass} href="${href}">${name}</a>`;
+            },
+        }
+    });
+
     return {
         markdownTemplateEngine: 'liquid',
         dir: {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -74,7 +74,7 @@ module.exports = function (eleventyConfig) {
             parse: function (tagToken, remainingTokens) {
                 // there's a better way to do this that's not in 11ty yet
                 // https://github.com/11ty/eleventy/issues/2679
-                let args = tagToken.args.split(' ');
+                let args = tagToken.args.split(',');
                 args = Object.fromEntries(args.map(arg => arg.split('=')));
                 this.hrefLink = args.link;
                 this.navbarLinkName = args.navbarLinkName;

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -69,29 +69,6 @@ module.exports = function (eleventyConfig) {
         }
     );
 
-    eleventyConfig.addLiquidTag('navbarLink', function (liquidEngine) {
-        return {
-            parse: function (tagToken, remainingTokens) {
-                // there's a better way to do this that's not in 11ty yet
-                // https://github.com/11ty/eleventy/issues/2679
-                let args = tagToken.args.split(',');
-                args = Object.fromEntries(args.map(arg => arg.split('=')));
-                this.hrefLink = args.link;
-                this.navbarLinkName = args.navbarLinkName;
-            },
-            render: async function (scope, hash) {
-                const context = scope.environments;
-                const pageUrl = context.page.url;
-                let href = await liquidEngine.evalValue(this.hrefLink, scope);
-                href += href.endsWith('/') ? '' : '/';
-                const name = await liquidEngine.evalValue(this.navbarLinkName, scope);
-                const activeLinkClass = pageUrl === href ? ' class="active"' : '';
-
-                return `<a ${activeLinkClass} href="${href}">${name}</a>`;
-            },
-        }
-    });
-
     return {
         markdownTemplateEngine: 'liquid',
         dir: {

--- a/src/_layouts/layout.liquid
+++ b/src/_layouts/layout.liquid
@@ -43,8 +43,8 @@
                 </div>
                 <div class="col-12 navbar__content mobile-hide tablet-hide">
                     <div class="navbar__left display-flex">
-                        {% navbarLink link='/careers' navbarLinkName='Careers' %}
-                        <a href="/about/">About Us</a>
+                        {% navbarLink link='/careers',navbarLinkName='Careers' %}
+                        {% navbarLink link='/about',navbarLinkName='About Us' %}
                         <!-- <a class="tablet-hide" href="/our-work/">Our Work</a> -->
                     </div>
                     <div class="navbar__title content--center">
@@ -57,8 +57,8 @@
                 </div>
                 <div class="col-12 navbar__content desktop-hide">
                     <div class="col-12 content--center">
-                        <a href="/careers/">Careers</a>
-                        <a href="/about/">About us</a>
+                        {% navbarLink link='/careers',navbarLinkName='Careers' %}
+                        {% navbarLink link='/about',navbarLinkName='About Us' %}
                         <!-- <a href="/our-work/">Our work</a> -->
                         <a href="mailto:hello@verdance.co">Contact us</a>
                     </div>

--- a/src/_layouts/layout.liquid
+++ b/src/_layouts/layout.liquid
@@ -43,7 +43,7 @@
                 </div>
                 <div class="col-12 navbar__content mobile-hide tablet-hide">
                     <div class="navbar__left display-flex">
-                        <a href="/careers/">Careers</a>
+                        {% navbarLink link='/careers' navbarLinkName='Careers' %}
                         <a href="/about/">About Us</a>
                         <!-- <a class="tablet-hide" href="/our-work/">Our Work</a> -->
                     </div>

--- a/src/_layouts/layout.liquid
+++ b/src/_layouts/layout.liquid
@@ -43,8 +43,8 @@
                 </div>
                 <div class="col-12 navbar__content mobile-hide tablet-hide">
                     <div class="navbar__left display-flex">
-                        {% navbarLink link='/careers',navbarLinkName='Careers' %}
-                        {% navbarLink link='/about',navbarLinkName='About Us' %}
+                        <a {% if page.url == "/careers/" %}class="active"{% endif %}  href="/careers/">Careers</a>
+                        <a {% if page.url == "/about/" %}class="active"{% endif %}  href="/about/">About Us</a>
                         <!-- <a class="tablet-hide" href="/our-work/">Our Work</a> -->
                     </div>
                     <div class="navbar__title content--center">
@@ -57,8 +57,8 @@
                 </div>
                 <div class="col-12 navbar__content desktop-hide">
                     <div class="col-12 content--center">
-                        {% navbarLink link='/careers',navbarLinkName='Careers' %}
-                        {% navbarLink link='/about',navbarLinkName='About Us' %}
+                        <a {% if page.url == "/careers" %}class="active"{% endif %}  href="/careers/">Careers</a>
+                        <a {% if page.url == "/about/" %}class="active"{% endif %}  href="/about/">About Us</a>
                         <!-- <a href="/our-work/">Our work</a> -->
                         <a href="mailto:hello@verdance.co">Contact us</a>
                     </div>

--- a/src/assets/styles/_page.scss
+++ b/src/assets/styles/_page.scss
@@ -100,3 +100,9 @@
     }
   }
 }
+
+.navbar {
+  a.active {
+    text-decoration: underline;
+  }
+}

--- a/src/assets/styles/_page.scss
+++ b/src/assets/styles/_page.scss
@@ -104,5 +104,7 @@
 .navbar {
   a.active {
     text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 4px;
   }
 }


### PR DESCRIPTION
I added an underline, but I think the design folks probably have better ideas on how to indicate active page and I can update `.active` from there.

This PR adds a new template tag `{% navbarLink %}` which checks to determine if that page is active and applies CSS if it's the active page.

![Screenshot 2024-06-25 at 3 35 24 PM](https://github.com/VerdanceTeam/verdance-site/assets/17188013/98f7ba1c-9fdf-4fac-bc79-50095884b0f5)
![Screenshot 2024-06-25 at 3 35 32 PM](https://github.com/VerdanceTeam/verdance-site/assets/17188013/e3f52f32-e48f-4be7-a49c-a8b3e2534adf)

Screenshot of feature w/ updated styles:
![Screenshot 2024-06-28 at 2 28 20 PM](https://github.com/VerdanceTeam/verdance-site/assets/17188013/0214127a-a54d-4adb-9ac2-8e8687019299)

