### PR TITLE
update black text to follow figma spec

### DIFF
--- a/src/assets/styles/_shared.scss
+++ b/src/assets/styles/_shared.scss
@@ -5,14 +5,17 @@
 .section {
   &--bg-linen {
     background-color: $linen;
+    color: $black;
   }
 
   &--bg-dark-linen {
     background-color: $dark-linen;
+    color: $black;
   }
 
   &--bg-chartreuse {
     background-color: $chartreuse;
+    color: $black;
   }
 
   &--bg-black {
@@ -262,7 +265,7 @@ h3 {
 
   a {
     align-self: flex-end;
-    color: inherit;
+    color: $black;
     font-family: 'PPNeueBitBold', 'Tahoma', 'san-serif';
     font-size: 18px;
     text-decoration: none;
@@ -302,6 +305,7 @@ h3 {
 
 .slogan-strip {
   @include grid-layout;
+  color: $black;
   margin: 0 14px;
   
   &__left {


### PR DESCRIPTION
When syncing w/ the team in #company-website for #11, I discovered that some of the text on the site is #000, but Jenn pointed out that all black text should follow the company color pallete.

This PR adds some additional CSS/SCSS `color:` rules in order to make black text on the current site follow company color `#01100B`

Related slack thread [HERE](https://verdance-workspace.slack.com/archives/C04PBN1L5L7/p1720220594660859).