### PR TITLE
fix margin for open roles apply button

### DIFF
--- a/src/assets/styles/_shared.scss
+++ b/src/assets/styles/_shared.scss
@@ -140,10 +140,10 @@
     p {
       line-height: 1em;
     }
+  }
 
-    &--cta {
-      margin-left: 8px;
-    }
+  &--cta {
+    margin-left: 8px;
   }
 }
 


### PR DESCRIPTION
When looking at Verdance.co site today I noticed the ... that connects open role sections clips directly into the apply button.
This PR fixes the CSS rule so the left margin is applied correctly here.

Before
![Screenshot 2024-10-25 at 10 45 38 AM](https://github.com/user-attachments/assets/516cd2f1-a543-4b42-8362-ad85baafe3a2)



After
![Screenshot 2024-10-25 at 10 52 42 AM](https://github.com/user-attachments/assets/4eb51371-30d3-4034-86c7-2540f6099e7e)
