### PR TITLE
Update copyright year to always be the current year

### DIFF
--- a/src/_includes/footer.liquid
+++ b/src/_includes/footer.liquid
@@ -133,7 +133,7 @@
                     <div
                         class="col-6 col-12-tablet col-12-mobile footer__copyright content--flex"
                     >
-                        <p class="footer__slogan">© 2025 Verdance LLC</p>
+                        <p class="footer__slogan">© {{ "today" | date: "%Y" }} Verdance LLC</p>
                         <div class="footer__icon-set">
                             <div class="footer__icon footer__icon--linen">
                                 {% svgIcon "/img/icons/leaf.svg" %}


### PR DESCRIPTION
<img width="278" height="216" alt="image" src="https://github.com/user-attachments/assets/1ea1ed66-a82c-47f4-a239-c0a2f63caff9" />

## Problem
I was motoring around the Verdance site today and noticed the copyright year was out of date.

## Solution
Updated the copyright year to always be the current year using Liquid's built-in date function.

Before | After
--- | ---
<img width="194" height="48" alt="image" src="https://github.com/user-attachments/assets/26f8533c-f56b-459a-965a-9ce859b06870" /> | <img width="190" height="40" alt="image" src="https://github.com/user-attachments/assets/e0eef60b-b3cc-44cb-85d8-a3d01d622618" />

## Testing
Pulled down the repo to run the site locally (great instructions in the readme!) and confirmed the change works as expected.