### PR TITLE
Rename Ideas to Insights, update routes and copy

### DIFF
--- a/src/_includes/blog_post_card.liquid
+++ b/src/_includes/blog_post_card.liquid
@@ -12,7 +12,7 @@
     {% endif %}
 
     <h2 class="blog-post-card__title">
-        <a href="/ideas/{{ post.slug | default : post.sys.id }}/">{{
+        <a href="/insights/{{ post.slug | default : post.sys.id }}/">{{
             post.title
         }}</a>
     </h2>
@@ -22,11 +22,11 @@
     </p>
 
     <p class="blog-post-card__readmore">
-        <a href="/ideas/{{ post.slug | default : post.sys.id }}/">Read more</a>
+        <a href="/insights/{{ post.slug | default : post.sys.id }}/">Read more</a>
     </p>
     {% if cta %}
     <div class="blog-post-card__cta">
-        {% include "button", text: "more posts ", href: "/ideas" %}
+        {% include "button", text: "more posts ", href: "/insights" %}
     </div>
     {% endif %}
 </article>

--- a/src/_includes/blog_post_card.liquid
+++ b/src/_includes/blog_post_card.liquid
@@ -26,7 +26,7 @@
     </p>
     {% if cta %}
     <div class="blog-post-card__cta">
-        {% include "button", text: "more posts ", href: "/insights" %}
+        {% include "button", text: "see all posts", href: "/insights" %}
     </div>
     {% endif %}
 </article>

--- a/src/_includes/footer.liquid
+++ b/src/_includes/footer.liquid
@@ -14,7 +14,7 @@
                             <div class="footer__links">
                                 <a href="/careers/">Careers</a>
                                 <a href="/about/">About Us</a>
-                                <a href="/ideas/">Ideas</a>
+                                <a href="/insights/">Insights</a>
                                 <a href="/our-work/">Our Work</a>
                                 <a href="mailto:hello@verdance.co"
                                     >Contact Us</a

--- a/src/_layouts/layout.liquid
+++ b/src/_layouts/layout.liquid
@@ -57,7 +57,7 @@
                         </a>
                     </div>
                     <div class="navbar__right content--right display-flex">
-                      <a {% if page.url contains "ideas" %}class="active"{% endif %} href="/ideas/">Ideas</a>
+                      <a {% if page.url contains "insights" %}class="active"{% endif %} href="/insights/">Insights</a>
                       <a {% if page.url contains "our-work" %}class="active"{% endif %} href="/our-work/">Our Work</a>
                         <a href="mailto:hello@verdance.co">Contact Us</a>
                     </div>
@@ -66,7 +66,7 @@
                     <div class="col-12 content--center">
                         <a {% if page.url contains "careers" %}class="active"{% endif %} href="/careers/">Careers</a>
                         <a {% if page.url contains "about" %}class="active"{% endif %} href="/about/">About Us</a>
-                        <a {% if page.url contains "ideas" %}class="active"{% endif %} href="/ideas/">Ideas</a>
+                        <a {% if page.url contains "insights" %}class="active"{% endif %} href="/insights/">Insights</a>
                         <a {% if page.url contains "our-work" %}class="active"{% endif %} href="/our-work/">Our Work</a>
                         <a href="mailto:hello@verdance.co">Contact us</a>
                     </div>

--- a/src/assets/styles/_page.scss
+++ b/src/assets/styles/_page.scss
@@ -311,6 +311,10 @@
     }
   }
 
+  & .blog-post-card {
+    padding: 8px 32px 32px 48px;
+  }
+
   @include tablet-media-query {
     .hero {
       padding-top: 8px;

--- a/src/assets/styles/_page.scss
+++ b/src/assets/styles/_page.scss
@@ -171,6 +171,18 @@
   & .blog-post-card {
     padding: 8px 8px 8px 32px;
   }
+
+  & .insights__heading {
+    padding-right: 24px;
+
+    @include tablet-media-query {
+      padding-right: 0;
+    }
+
+    @include mobile-media-query {
+      padding-right: 0;
+    }
+  }
 }
 
 .about-page {

--- a/src/assets/styles/_page.scss
+++ b/src/assets/styles/_page.scss
@@ -312,7 +312,7 @@
   }
 
   & .blog-post-card {
-    padding: 8px 32px 32px 48px;
+    padding: 8px 16px 32px 16px;
   }
 
   @include tablet-media-query {

--- a/src/pages/blog.liquid
+++ b/src/pages/blog.liquid
@@ -1,7 +1,7 @@
 ---
 layout: layout.liquid
-title: Verdance | Ideas
-permalink: /ideas/
+title: Verdance | Insights
+permalink: /insights/
 ---
 
 <div class="blog-page">

--- a/src/pages/ideas-post-redirect.liquid
+++ b/src/pages/ideas-post-redirect.liquid
@@ -1,0 +1,18 @@
+---
+pagination:
+    data: posts
+    size: 1
+    alias: post
+permalink: "/ideas/{{ post.slug | default: post.sys.id }}/index.html"
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; url=/insights/{{ post.slug | default: post.sys.id }}/" />
+    <link rel="canonical" href="/insights/{{ post.slug | default: post.sys.id }}/" />
+  </head>
+  <body>
+    <script>window.location.replace('/insights/{{ post.slug | default: post.sys.id }}/');</script>
+  </body>
+</html>

--- a/src/pages/ideas-redirect.liquid
+++ b/src/pages/ideas-redirect.liquid
@@ -1,0 +1,14 @@
+---
+permalink: /ideas/
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; url=/insights/" />
+    <link rel="canonical" href="/insights/" />
+  </head>
+  <body>
+    <script>window.location.replace('/insights/');</script>
+  </body>
+</html>

--- a/src/pages/index.liquid
+++ b/src/pages/index.liquid
@@ -255,7 +255,7 @@ permalink: /
     <section class="experience section--spacing section--bg-dark-linen">
         <div class="container">
             <p class="col-12 section--subtitle">insights</p>
-            <div class="col-6 col-12-tablet col-12-mobile">
+            <div class="col-6 col-12-tablet col-12-mobile insights__heading">
                 <h1 class="col-5 col-6-tablet col-12-mobile">
                     Our work spans people, technology, process, and policy. Here's what we're seeing and learning.
                 </h1>

--- a/src/pages/index.liquid
+++ b/src/pages/index.liquid
@@ -146,7 +146,7 @@ permalink: /
                             </div>
                             <div class="toc--item">
                                 <div class="dot-leader">
-                                    <p>Department of Veteran Affairs</p>
+                                    <p>Department of Veterans Affairs</p>
                                     <div class="hr"></div>
                                     <img
                                         src="/assets/img/partners/VA-seal.png"
@@ -254,10 +254,10 @@ permalink: /
     latest %}
     <section class="experience section--spacing section--bg-dark-linen">
         <div class="container">
-            <p class="col-12 section--subtitle">ideas</p>
+            <p class="col-12 section--subtitle">insights</p>
             <div class="col-6 col-12-tablet col-12-mobile">
                 <h1 class="col-5 col-6-tablet col-12-mobile">
-                    We value autonomy, trust, and flexibility.
+                    Our work spans people, technology, process, and policy. Here's what we're seeing and learning.
                 </h1>
             </div>
             <div

--- a/src/pages/post-pages.liquid
+++ b/src/pages/post-pages.liquid
@@ -3,7 +3,7 @@ pagination:
     data: posts
     size: 1
     alias: post
-permalink: /ideas/{{ post.sys.id }}/index.html
+permalink: /insights/{{ post.sys.id }}/index.html
 layout: layout.liquid
 eleventyComputed:
     date: '{{ post.sys.publishedAt }}'
@@ -81,7 +81,7 @@ eleventyComputed:
             </div>
             {% endif %}
             <div class="content--wrapper col-12 blog-post-card__cta">
-                {% include "button", text: "more posts ", href: "/ideas" %}
+                {% include "button", text: "more posts ", href: "/insights" %}
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary

- Renames "Ideas" → "Insights" across nav, footer, and page title
- Moves all routes from `/ideas/` → `/insights/` (index and individual posts)
- Adds HTML redirect pages at `/ideas/` and `/ideas/:slug/` so existing links don't break
- Increases blog post card left padding on `/insights/` page for better breathing room from the dotted border
- Fixes typo: "Department of Veteran Affairs" → "Department of Veterans Affairs"
- Updates homepage insights section copy to match subject material, it was holdover content from elsewhere

## Test plan

- [ ] Nav link reads "INSIGHTS" and routes to `/insights/`
- [ ] Footer link reads "Insights" and routes to `/insights/`
- [ ] Visiting `/ideas/` redirects to `/insights/`
- [ ] Visiting `/ideas/:slug` redirects to `/insights/:slug`
- [ ] Blog post cards on `/insights/` have comfortable left padding
- [ ] Homepage insights section shows updated heading copy
- [ ] "Department of Veterans Affairs" correct on homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)