### PR TITLE
Fixes for Blog post view page

### DIFF
--- a/src/_data/localDummyPosts.js
+++ b/src/_data/localDummyPosts.js
@@ -64,9 +64,31 @@ const LOCAL_DUMMY_POSTS = [
             paragraphNode(
                 'Suspendisse potenti. Praesent suscipit, nibh in aliquet fermentum, nibh ipsum pretium augue, vitae sodales purus lacus id lacus. Integer volutpat urna sed magna tincidunt, a pretium orci ullamcorper.'
             ),
-            paragraphNode(
-                'Curabitur ultrices, lectus vel lacinia fermentum, arcu mauris tempor odio, non dignissim erat libero quis augue. Donec id risus eu odio posuere consectetur et a magna.'
-            ),
+            {
+                nodeType: 'paragraph',
+                data: {},
+                content: [
+                    textNode(
+                        'Curabitur ultrices, lectus vel lacinia fermentum, arcu mauris tempor odio. Read more in '
+                    ),
+                    {
+                        nodeType: 'hyperlink',
+                        data: {
+                            uri: 'https://www.18f.gov/',
+                        },
+                        content: [textNode('18F')],
+                    },
+                    textNode(' and explore delivery resources at '),
+                    {
+                        nodeType: 'hyperlink',
+                        data: {
+                            uri: 'https://digital.gov/',
+                        },
+                        content: [textNode('Digital.gov')],
+                    },
+                    textNode('.'),
+                ],
+            },
             paragraphNode(
                 'Mauris faucibus, mi at blandit feugiat, tortor urna fringilla nisi, vitae tempor mauris libero eget mauris. Morbi ultrices malesuada justo, ac laoreet augue pretium vel.'
             ),

--- a/src/assets/styles/_foundation.scss
+++ b/src/assets/styles/_foundation.scss
@@ -6,6 +6,7 @@ $chartreuse-transparent: rgba(232, 255, 142, 0.5);
 $dark-linen: #E6DED3;
 $forest: #006C4D;
 $forest-transparent: rgba(0, 108, 77, 0.5);
+$grey: #5E6964;
 $linen: #F3F0EC;
 $neon: #8DFF7B;
 

--- a/src/assets/styles/_page.scss
+++ b/src/assets/styles/_page.scss
@@ -341,6 +341,14 @@
 }
 
 .blog-post-page {
+  .blog-rich-text {
+    a,
+    a:visited {
+      color: $grey;
+      text-decoration: underline;
+    }
+  }
+
   .container {
     max-width: $blog-post-max-width;
   }

--- a/src/pages/post-pages.liquid
+++ b/src/pages/post-pages.liquid
@@ -11,7 +11,7 @@ eleventyComputed:
 ---
 
 <article class="section--spacing section--bg-linen blog-post-page">
-    <header class="section">
+    <header class="section blog-rich-text">
         <div class="container section--intro">
             <div class="col-12 padding-bottom-32">
                 <h1>{{ post.title }}</h1>
@@ -32,7 +32,7 @@ eleventyComputed:
         </div>
     </header>
 
-    <section class="section">
+    <section class="section blog-rich-text">
         <div class="container section--content-block">
             {% if post.tldr %}
             <div class="content--wrapper col-12">
@@ -81,6 +81,11 @@ eleventyComputed:
                 {% renderRichText post.content %}
             </div>
             {% endif %}
+        </div>
+    </section>
+
+    <section class="section">
+        <div class="container section--content-block">
             <div class="content--wrapper col-12 blog-post-card__cta">
                 {% include "button", text: "more posts ", href: "/insights" %}
             </div>

--- a/src/pages/post-pages.liquid
+++ b/src/pages/post-pages.liquid
@@ -6,6 +6,7 @@ pagination:
 permalink: /insights/{{ post.sys.id }}/index.html
 layout: layout.liquid
 eleventyComputed:
+    title: '{{ post.title }}'
     date: '{{ post.sys.publishedAt }}'
 ---
 


### PR DESCRIPTION
## Overview
This pull request aims to do the following:

- Fixes https://github.com/VerdanceTeam/verdance-site/issues/108
- Fixes https://github.com/VerdanceTeam/verdance-site/issues/101

## Notes:
- After reviewing the links for pullquotes, I discovered that they use the same color as the blog content. Using the exact same color made links indiscernible.
- I instead added a new `$grey` and had cursor do a quick accessibility check:

<img width="393" height="380" alt="Screenshot 2026-05-07 at 1 37 40 PM" src="https://github.com/user-attachments/assets/53e7e2bf-773d-4945-bb5b-ab05df60f261" />



## Screenshots:

### Title update

<img width="1301" height="678" alt="Screenshot 2026-05-07 at 1 13 49 PM" src="https://github.com/user-attachments/assets/5c4239c0-b913-435c-b196-35933714c082" />

### Links
#### Before:
<img width="924" height="520" alt="Screenshot 2026-05-07 at 1 20 34 PM" src="https://github.com/user-attachments/assets/37e6987d-9849-4936-947c-5d978d462477" />


#### After:
<img width="1081" height="770" alt="Screenshot 2026-05-07 at 2 01 19 PM" src="https://github.com/user-attachments/assets/72168410-ed91-4afb-8001-e898edd78804" />
