### PR TITLE
add "AI-fluent" link to homepage hero with sparkle hover

### DIFF
--- a/src/_includes/section_roles.liquid
+++ b/src/_includes/section_roles.liquid
@@ -28,7 +28,9 @@
                         <p class="col-12 large-text">
                             We don't have any open roles right now, but check
                             back soon.
-                            <span class="job--title vertical-align-sub"
+                            <span
+                                class="job--title job--empty-icon"
+                                aria-hidden="true"
                                 >{% svgIcon "/img/icons/leaf.svg" %}</span
                             >
                         </p>

--- a/src/_includes/section_roles.liquid
+++ b/src/_includes/section_roles.liquid
@@ -28,9 +28,7 @@
                         <p class="col-12 large-text">
                             We don't have any open roles right now, but check
                             back soon.
-                            <span
-                                class="job--title job--empty-icon"
-                                aria-hidden="true"
+                            <span class="job--title job--empty-leaf-offset vertical-align-sub"
                                 >{% svgIcon "/img/icons/leaf.svg" %}</span
                             >
                         </p>

--- a/src/assets/styles/_shared.scss
+++ b/src/assets/styles/_shared.scss
@@ -204,14 +204,12 @@
     }
   }
 
-  &--empty-icon {
-    display: block;
-    line-height: 0;
-    margin-top: 8px;
-    text-align: right;
+  &--empty-leaf-offset {
+    display: inline-block;
 
     svg {
-      padding-right: 0;
+      display: inline-block;
+      transform: translateX(20px);
     }
   }
 

--- a/src/assets/styles/_shared.scss
+++ b/src/assets/styles/_shared.scss
@@ -204,6 +204,16 @@
     }
   }
 
+  &--empty-icon {
+    display: block;
+    line-height: 0;
+    margin-top: 8px;
+
+    svg {
+      padding-right: 0;
+    }
+  }
+
   &--cta {
     margin-left: 8px;
   }

--- a/src/assets/styles/_shared.scss
+++ b/src/assets/styles/_shared.scss
@@ -130,23 +130,30 @@
   }
 
   &:hover::before {
-    animation: ai-fluent-sparkle 1.2s ease-in-out infinite;
+    animation: ai-fluent-sparkle 1.8s ease-in-out infinite;
   }
 
   &:hover::after {
-    animation: ai-fluent-sparkle 1.2s ease-in-out 0.4s infinite;
+    animation: ai-fluent-sparkle 1.8s ease-in-out 0.12s infinite;
   }
 }
 
 @keyframes ai-fluent-sparkle {
-  0%,
+  0% {
+    opacity: 1;
+    transform: scale(0.75) rotate(0deg);
+  }
+  35% {
+    opacity: 1;
+    transform: scale(1) rotate(150deg);
+  }
+  75% {
+    opacity: 0;
+    transform: scale(0.15) rotate(300deg);
+  }
   100% {
     opacity: 0;
-    transform: scale(0) rotate(0deg);
-  }
-  50% {
-    opacity: 1;
-    transform: scale(1) rotate(180deg);
+    transform: scale(0) rotate(360deg);
   }
 }
 

--- a/src/assets/styles/_shared.scss
+++ b/src/assets/styles/_shared.scss
@@ -208,6 +208,7 @@
     display: block;
     line-height: 0;
     margin-top: 8px;
+    text-align: right;
 
     svg {
       padding-right: 0;

--- a/src/assets/styles/_shared.scss
+++ b/src/assets/styles/_shared.scss
@@ -88,6 +88,68 @@
   }
 }
 
+.ai-fluent-link {
+  position: relative;
+  color: $black;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 3px;
+  cursor: pointer;
+
+  &:visited,
+  &:hover,
+  &:active,
+  &:focus {
+    color: $black;
+  }
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M6 0 L7 5 L12 6 L7 7 L6 12 L5 7 L0 6 L5 5 Z' fill='%2301100B'/></svg>");
+    background-size: contain;
+    background-repeat: no-repeat;
+    opacity: 0;
+    pointer-events: none;
+    transform: scale(0);
+  }
+
+  &::before {
+    top: -8px;
+    left: -10px;
+    width: 10px;
+    height: 10px;
+  }
+
+  &::after {
+    bottom: -4px;
+    right: -10px;
+    width: 7px;
+    height: 7px;
+  }
+
+  &:hover::before {
+    animation: ai-fluent-sparkle 1.2s ease-in-out infinite;
+  }
+
+  &:hover::after {
+    animation: ai-fluent-sparkle 1.2s ease-in-out 0.4s infinite;
+  }
+}
+
+@keyframes ai-fluent-sparkle {
+  0%,
+  100% {
+    opacity: 0;
+    transform: scale(0) rotate(0deg);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1) rotate(180deg);
+  }
+}
+
 .button {
   background-color: $black;
   border-radius: 2px;

--- a/src/assets/styles/_shared.scss
+++ b/src/assets/styles/_shared.scss
@@ -129,11 +129,13 @@
     height: 7px;
   }
 
-  &:hover::before {
+  &:hover::before,
+  &:focus-visible::before {
     animation: ai-fluent-sparkle 1.8s ease-in-out infinite;
   }
 
-  &:hover::after {
+  &:hover::after,
+  &:focus-visible::after {
     animation: ai-fluent-sparkle 1.8s ease-in-out 0.12s infinite;
   }
 }

--- a/src/pages/about.liquid
+++ b/src/pages/about.liquid
@@ -28,17 +28,17 @@ permalink: /about/
                     <h1
                         class="col-5 col-12-tablet col-12-mobile section--spacing"
                     >
-                        The world of civic technology is wide and complex.
+                         We're at an inflection point for government digital services.
                     </h1>
                     <div class="col-1 tablet-hide mobile-hide"></div>
                     <div
                         class="col-5 col-12-tablet col-12-mobile content--bottom section--spacing"
                     >
                         <p>
-                            It’s often a substantial adjustment for folks who
-                            haven’t previously done government work. Here are a
-                            few of our strongly held beliefs about succeeding as
-                            technologists in government:
+                            With the talent and technology that exists today, 
+                            there's never been a better time to rethink and rebuild systems that have long needed change.
+                            Here are some of the principles guiding our team through this difficult but transformative work:
+
                         </p>
                     </div>
                     <div class="col-1 tablet-hide mobile-hide"></div>
@@ -52,12 +52,11 @@ permalink: /about/
                         </div>
                         <h2>Everyone is a builder</h2>
                         <p>
-                            The line between product, design, and engineering
-                            is thinner than it’s ever been. We expect everyone
-                            on our team to ship: to prototype, to write code
-                            alongside AI tools, and to stay close to the craft.
-                            Distance from the work is distance from the
-                            problem.
+                            Everyone has a role to play in shipping. Product
+                            and design are more empowered than ever to 
+                            contribute product changes directly using AI tools. Across
+                            every discipline, we hire and train people who
+                            think of themselves as builders.
                         </p>
                     </div>
                     <div class="col-1 tablet-hide mobile-hide"></div>
@@ -90,12 +89,11 @@ permalink: /about/
                         <p>
                             As technologists in government, our backgrounds
                             often differ from the people we work with. The
-                            relationships we build (with clients, partners,
+                            relationships we build—with clients, partners,
                             and the agency staff one or two layers removed
-                            from us) are what let our impact compound over
+                            from us—are what let our impact compound over
                             the long run. We take the extra step to understand
-                            other perspectives, especially when they’re
-                            nothing like our own.
+                            the breadth of perspectives held by our collaborators.
                         </p>
                     </div>
                     <div class="col-1 tablet-hide mobile-hide"></div>
@@ -109,10 +107,10 @@ permalink: /about/
                         <p>
                             We center the public interest in our thinking. In
                             complex government systems, and especially in
-                            systems where AI is now part of the decision loop,
+                            ones where AI is now part of the decision loop,
                             it’s easy to miss the forest for the trees. When
                             the public interest perspective is missing from
-                            the conversation, we go out of our way to add it.
+                            the conversation, we strive to add it.
                         </p>
                     </div>
                     <div class="col-1 tablet-hide mobile-hide"></div>
@@ -130,9 +128,7 @@ permalink: /about/
                             unafraid to compromise to move forward. We believe
                             in incremental, repeatable progress over the long
                             run, and we celebrate the small and medium wins as
-                            much as the big ones. The first version is rarely
-                            the right one, but it’s the one that teaches you
-                            what is.
+                            much as the big ones. 
                         </p>
                     </div>
                     <div class="col-1 tablet-hide mobile-hide"></div>

--- a/src/pages/about.liquid
+++ b/src/pages/about.liquid
@@ -9,8 +9,8 @@ permalink: /about/
         <div class="container">
             <div class="hero__content col-12">
                 <h1>
-                    We continuously refine our approach <br />
-                    to delivering successful digital services.
+                    We’re building the public interest technology firm <br />
+                    for the AI era.
                 </h1>
                 <img src="/assets/img/HeroNetwork-resized.webp" />
                 <div class="hero__cta">
@@ -48,20 +48,38 @@ permalink: /about/
                         class="col-5 col-12-tablet col-12-mobile section--spacing"
                     >
                         <div class="who-we-are__icon">
+                            <img src="/assets/img/spots/hands.webp" />
+                        </div>
+                        <h2>Everyone is a builder</h2>
+                        <p>
+                            The line between product, design, and engineering
+                            is thinner than it’s ever been. We expect everyone
+                            on our team to ship: to prototype, to write code
+                            alongside AI tools, and to stay close to the craft.
+                            Distance from the work is distance from the
+                            problem.
+                        </p>
+                    </div>
+                    <div class="col-1 tablet-hide mobile-hide"></div>
+                    <div
+                        class="col-5 col-12-tablet col-12-mobile section--spacing"
+                    >
+                        <div class="who-we-are__icon">
                             <img src="/assets/img/spots/network.webp" />
                         </div>
                         <h2>Think in systems</h2>
                         <p>
-                            Our work often affects technology, policy, and
-                            people, and most of what we do has second-order
-                            effects. If we strive to understand and predict the
-                            effects of an intervention on the whole system, we
-                            have a better handle on our impact. We remain
-                            focused on our piece of the puzzle, but we avoid
-                            silos and don’t shy away from the big picture.
+                            Our work touches technology, policy, and people,
+                            and most of it has second-order effects. When we
+                            understand the whole system, we have a better
+                            handle on our impact. We stay focused on our piece
+                            of the puzzle, but we don’t shy away from the big
+                            picture, and we don’t build in silos.
                         </p>
                     </div>
                     <div class="col-1 tablet-hide mobile-hide"></div>
+                </div>
+                <div class="section--content-block">
                     <div
                         class="col-5 col-12-tablet col-12-mobile section--spacing"
                     >
@@ -70,21 +88,17 @@ permalink: /about/
                         </div>
                         <h2>Build bridges, not just tech</h2>
                         <p>
-                            As technologists working in government, our
-                            backgrounds can often be different from the folks we
-                            interact with. The relationships we build - with our
-                            clients, with partner companies, and with government
-                            folks once or twice removed from our direct
-                            stakeholders - give us the ability to continue to
-                            grow and scale our impact over the long-term. We
-                            take the extra step to understand the perspective of
-                            folks with different backgrounds or prior experience
-                            than ours.
+                            As technologists in government, our backgrounds
+                            often differ from the people we work with. The
+                            relationships we build (with clients, partners,
+                            and the agency staff one or two layers removed
+                            from us) are what let our impact compound over
+                            the long run. We take the extra step to understand
+                            other perspectives, especially when they’re
+                            nothing like our own.
                         </p>
                     </div>
                     <div class="col-1 tablet-hide mobile-hide"></div>
-                </div>
-                <div class="section--content-block">
                     <div
                         class="col-5 col-12-tablet col-12-mobile section--spacing"
                     >
@@ -93,28 +107,12 @@ permalink: /about/
                         </div>
                         <h2>Advocate for the public interest</h2>
                         <p>
-                            We strive to center the public interest in our
-                            thinking. When shaping complex government systems,
-                            it’s easy to miss the forest for the trees. If the
-                            public interest perspective is missing in the
-                            conversation, we go out of our way to respectfully
-                            add it.
-                        </p>
-                    </div>
-                    <div class="col-1 tablet-hide mobile-hide"></div>
-                    <div
-                        class="col-5 col-12-tablet col-12-mobile section--spacing"
-                    >
-                        <div class="who-we-are__icon">
-                            <img src="/assets/img/spots/satellite.webp" />
-                        </div>
-                        <h2>Compromise is vital</h2>
-                        <p>
-                            We bring healthy idealism to the table, but are
-                            unafraid to compromise in order to move forward. We
-                            believe in incremental, repeatable progress over the
-                            long run, and we celebrate the small and medium
-                            sized wins as well as the large ones.
+                            We center the public interest in our thinking. In
+                            complex government systems, and especially in
+                            systems where AI is now part of the decision loop,
+                            it’s easy to miss the forest for the trees. When
+                            the public interest perspective is missing from
+                            the conversation, we go out of our way to add it.
                         </p>
                     </div>
                     <div class="col-1 tablet-hide mobile-hide"></div>
@@ -124,16 +122,34 @@ permalink: /about/
                         class="col-5 col-12-tablet col-12-mobile section--spacing"
                     >
                         <div class="who-we-are__icon">
+                            <img src="/assets/img/spots/satellite.webp" />
+                        </div>
+                        <h2>Ship and refine</h2>
+                        <p>
+                            We bring healthy idealism to the table, and we’re
+                            unafraid to compromise to move forward. We believe
+                            in incremental, repeatable progress over the long
+                            run, and we celebrate the small and medium wins as
+                            much as the big ones. The first version is rarely
+                            the right one, but it’s the one that teaches you
+                            what is.
+                        </p>
+                    </div>
+                    <div class="col-1 tablet-hide mobile-hide"></div>
+                    <div
+                        class="col-5 col-12-tablet col-12-mobile section--spacing"
+                    >
+                        <div class="who-we-are__icon">
                             <img src="/assets/img/spots/window.webp" />
                         </div>
                         <h2>Balance is mission-critical</h2>
                         <p>
-                            Mission-oriented work too often leads to burnout and
-                            exhaustion. We build technology to build public
-                            trust, but keeping levity and humanity at the core
-                            of our work is key to longevity. We do our best to
-                            be cognizant of the balance that’s necessary to be
-                            around for the long term.
+                            Mission-oriented work too often leads to burnout.
+                            We build technology to build public trust, and
+                            keeping levity and humanity at the core of our
+                            work is how we stay around to do it. We try to be
+                            honest about the balance that long-term impact
+                            requires.
                         </p>
                     </div>
                     <div class="col-1 tablet-hide mobile-hide"></div>

--- a/src/pages/about.liquid
+++ b/src/pages/about.liquid
@@ -37,7 +37,7 @@ permalink: /about/
                         <p>
                             With the talent and technology that exists today, 
                             there's never been a better time to rethink and rebuild systems that have long needed change.
-                            Here are some of the principles guiding our team through this difficult but transformative work:
+                            Here are some of the principles guiding our team through this challenging but transformative work:
 
                         </p>
                     </div>

--- a/src/pages/careers.liquid
+++ b/src/pages/careers.liquid
@@ -25,18 +25,33 @@ permalink: /careers/
                                     what type of team we're building
                                 </p>
                                 <p>
-                                    Though we're a small team (for now), the breadth
-                                    of our work is remarkable—we're working on
-                                    critical, impactful projects across several
-                                    agencies.
+                                    Our team is small relative to the breadth
+                                    of our work. We ship critical projects
+                                    across several federal agencies, and we
+                                    punch well above our weight.
                                 </p>
                                 <p>&nbsp;</p>
                                 <p>
-                                    We're up for the challenge of making digital
-                                    services more effective, and we're building
-                                    an ambitious, talented team. At the same
-                                    time, we prize humility, playfulness, and
-                                    patience.
+                                    We believe everyone on our team is a
+                                    builder. Product managers prototype.
+                                    Designers contribute directly to pixel
+                                    perfection. Engineers are expected to
+                                    have strong product instincts. AI tools
+                                    have collapsed the distance between idea
+                                    and artifact, and we expect everyone on
+                                    our team to use them to stay close to
+                                    the work. We hire people who want to
+                                    build, not just plan, and who can pair
+                                    AI speed with the human judgment that
+                                    public interest work demands.
+                                </p>
+                                <p>&nbsp;</p>
+                                <p>
+                                    We're up for the challenge of making
+                                    digital services more effective, and
+                                    we're growing an ambitious, talented
+                                    team. At the same time, we prize
+                                    humility, playfulness, and patience.
                                 </p>
                             </div>
                             <div class="desktop-hide">
@@ -45,11 +60,33 @@ permalink: /careers/
                                     what type of team we're building
                                 </p>
                                 <p>
-                                    We're up for the challenge of making digital
-                                    services more effective, and we're building
-                                    an ambitious, talented team. At the same
-                                    time, we prize humility, playfulness, and
-                                    patience.
+                                    Our team is small relative to the breadth
+                                    of our work. We ship critical projects
+                                    across several federal agencies, and we
+                                    punch well above our weight.
+                                </p>
+                                <p>&nbsp;</p>
+                                <p>
+                                    We believe everyone on our team is a
+                                    builder. Product managers prototype.
+                                    Designers contribute directly to pixel
+                                    perfection. Engineers are expected to
+                                    have strong product instincts. AI tools
+                                    have collapsed the distance between idea
+                                    and artifact, and we expect everyone on
+                                    our team to use them to stay close to
+                                    the work. We hire people who want to
+                                    build, not just plan, and who can pair
+                                    AI speed with the human judgment that
+                                    public interest work demands.
+                                </p>
+                                <p>&nbsp;</p>
+                                <p>
+                                    We're up for the challenge of making
+                                    digital services more effective, and
+                                    we're growing an ambitious, talented
+                                    team. At the same time, we prize
+                                    humility, playfulness, and patience.
                                 </p>
                             </div>
                         </div>

--- a/src/pages/careers.liquid
+++ b/src/pages/careers.liquid
@@ -15,7 +15,10 @@ permalink: /careers/
                         >
                             <h1>We're a home for curious technologists.</h1>
                             <img class="group-photo" src="/assets/img/GroupChicago.jpg" />
-                            <p>The team from our 2025 Chicago offsite </p>
+                            <p>
+                                Enjoying some downtime during our 2025 Chicago
+                                offsite
+                            </p>
                         </div>
                         <div class="col-6 col-12-tablet col-12-mobile">
                             <div

--- a/src/pages/index.liquid
+++ b/src/pages/index.liquid
@@ -14,17 +14,18 @@ permalink: /
                     resilient and respectful digital services.
                 </h1>
                 <p class="hero__subhero mobile-hide tablet-hide">
-                    Verdance is a consultancy using design and technology to
-                    help government agencies transform
+                    Verdance is an <a class="ai-fluent-link" href="#">AI-fluent</a>
+                    consultancy using design and technology to help government
+                    agencies transform
                     <br />
                     customer experiences, enhance data quality and availability,
                     and make efficient, accurate decisions.
                 </p>
                 <p class="hero__subhero desktop-hide">
-                    Verdance is a consultancy using design and technology to
-                    help government agencies transform customer experiences,
-                    enhance data quality and availability, and make efficient,
-                    accurate decisions.
+                    Verdance is an <a class="ai-fluent-link" href="#">AI-fluent</a>
+                    consultancy using design and technology to help government
+                    agencies transform customer experiences, enhance data quality
+                    and availability, and make efficient, accurate decisions.
                 </p>
                 <picture>
                     <source

--- a/src/pages/index.liquid
+++ b/src/pages/index.liquid
@@ -17,9 +17,10 @@ permalink: /
                     Verdance is an <a class="ai-fluent-link" href="#">AI-fluent</a>
                     consultancy using design and technology to bridge the gap 
                     between
-                    policy and
-                    <br />
-                    implementation, enhance data quality and availability,
+                    policy intentions and
+                    <br>
+                    implementation outcomes,
+                    enhance data quality and availability,
                     and positively transform customer experiences.
                 </p>
                 <p class="hero__subhero desktop-hide">

--- a/src/pages/index.liquid
+++ b/src/pages/index.liquid
@@ -10,16 +10,17 @@ permalink: /
             <div class="col-1"></div>
             <div class="hero__content col-10">
                 <h1>
-                    We partner with government to build <br />
-                    resilient and respectful digital services.
+                    We partner with government to craft <br />
+                    the digital services of tomorrow.
                 </h1>
                 <p class="hero__subhero mobile-hide tablet-hide">
                     Verdance is an <a class="ai-fluent-link" href="#">AI-fluent</a>
-                    consultancy using design and technology to help government
-                    agencies transform
+                    consultancy using design and technology to bridge the gap 
+                    between
+                    policy and
                     <br />
-                    customer experiences, enhance data quality and availability,
-                    and make efficient, accurate decisions.
+                    implementation, enhance data quality and availability,
+                    and positively transform customer experiences.
                 </p>
                 <p class="hero__subhero desktop-hide">
                     Verdance is an <a class="ai-fluent-link" href="#">AI-fluent</a>

--- a/src/pages/index.liquid
+++ b/src/pages/index.liquid
@@ -14,7 +14,7 @@ permalink: /
                     the digital services of tomorrow.
                 </h1>
                 <p class="hero__subhero mobile-hide tablet-hide">
-                    Verdance is an <a class="ai-fluent-link" href="#">AI-fluent</a>
+                    Verdance is an <a class="ai-fluent-link" href="/careers/">AI-fluent</a>
                     consultancy using design and technology to bridge the gap 
                     between
                     policy intentions and
@@ -24,7 +24,7 @@ permalink: /
                     and positively transform customer experiences.
                 </p>
                 <p class="hero__subhero desktop-hide">
-                    Verdance is an <a class="ai-fluent-link" href="#">AI-fluent</a>
+                    Verdance is an <a class="ai-fluent-link" href="/careers/">AI-fluent</a>
                     consultancy using design and technology to help government
                     agencies transform customer experiences, enhance data quality
                     and availability, and make efficient, accurate decisions.


### PR DESCRIPTION
Updates copy.

 "AI-fluent" is wrapped in an inline link styled with a dotted underline and a subtle two-star sparkle that twinkles on hover. 
 
 Also moves the leaf icon that appears when there are no jobs 20px to the right - it always looked cramped.